### PR TITLE
Core 746 upgrade simple cache 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">= 8.0",
-        "psr/simple-cache": "^2"
+        "psr/simple-cache": "^3"
     },
     "require-dev": {
         "codeception/codeception": "^5",

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -116,10 +116,6 @@ class MockCache implements CacheInterface
 
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
-        if (! is_array($keys) && ! $keys instanceof Traversable) {
-            throw new InvalidArgumentException("keys must be either of type array or Traversable");
-        }
-
         $values = [];
 
         foreach ($keys as $key) {
@@ -132,10 +128,6 @@ class MockCache implements CacheInterface
 
     public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool
     {
-        if (! is_array($values) && ! $values instanceof Traversable) {
-            throw new InvalidArgumentException("keys must be either of type array or Traversable");
-        }
-
         foreach ($values as $key => $value) {
             $this->validateKey($key);
             $this->set($key, $value, $ttl);

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -114,7 +114,7 @@ class MockCache implements CacheInterface
         return true;
     }
 
-    public function getMultiple($keys, $default = null)
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         if (! is_array($keys) && ! $keys instanceof Traversable) {
             throw new InvalidArgumentException("keys must be either of type array or Traversable");

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -106,10 +106,12 @@ class MockCache implements CacheInterface
         return $success;
     }
 
-    public function clear()
+    public function clear(): bool
     {
         $this->cache = [];
         $this->cache_expiration = [];
+
+        return true;
     }
 
     public function getMultiple($keys, $default = null)

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -138,10 +138,6 @@ class MockCache implements CacheInterface
 
     public function deleteMultiple(iterable $keys): bool
     {
-        if (! is_array($keys) && ! $keys instanceof Traversable) {
-            throw new InvalidArgumentException("keys must be either of type array or Traversable");
-        }
-
         foreach ($keys as $key) {
             $this->validateKey($key);
             $this->delete($key);

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -130,7 +130,7 @@ class MockCache implements CacheInterface
         return $values;
     }
 
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool
     {
         if (! is_array($values) && ! $values instanceof Traversable) {
             throw new InvalidArgumentException("keys must be either of type array or Traversable");

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -61,7 +61,7 @@ class MockCache implements CacheInterface
         $this->time += $seconds;
     }
 
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         $this->validateKey($key);
 

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -158,7 +158,7 @@ class MockCache implements CacheInterface
         return true;
     }
 
-    public function has($key)
+    public function has(string $key): bool
     {
         return $this->get($key, $this) !== $this;
     }

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -90,7 +90,7 @@ class MockCache implements CacheInterface
         return true;
     }
 
-    public function delete($key)
+    public function delete(string $key): bool
     {
         $this->validateKey($key);
 

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -70,7 +70,7 @@ class MockCache implements CacheInterface
             : $default;
     }
 
-    public function set($key, $value, $ttl = null)
+    public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
         $this->validateKey($key);
 

--- a/src/MockCache.php
+++ b/src/MockCache.php
@@ -144,7 +144,7 @@ class MockCache implements CacheInterface
         return true;
     }
 
-    public function deleteMultiple($keys)
+    public function deleteMultiple(iterable $keys): bool
     {
         if (! is_array($keys) && ! $keys instanceof Traversable) {
             throw new InvalidArgumentException("keys must be either of type array or Traversable");
@@ -154,6 +154,8 @@ class MockCache implements CacheInterface
             $this->validateKey($key);
             $this->delete($key);
         }
+
+        return true;
     }
 
     public function has($key)

--- a/tests/unit/MockCacheCest.php
+++ b/tests/unit/MockCacheCest.php
@@ -158,7 +158,7 @@ class MockCacheCest
 
         $I->assertSame("value3", $this->cache->get("key3"));
 
-        $I->expectThrowable(InvalidArgumentException::class, function () {
+        $I->expectThrowable(TypeError::class, function () {
             $this->cache->deleteMultiple("Invalid type");
         });
 

--- a/tests/unit/MockCacheCest.php
+++ b/tests/unit/MockCacheCest.php
@@ -5,6 +5,7 @@ namespace Kodus\Cache\Test\Unit;
 use DateInterval;
 use Kodus\Cache\MockCache;
 use Kodus\Cache\InvalidArgumentException;
+use TypeError;
 use UnitTester;
 
 class MockCacheCest
@@ -130,11 +131,11 @@ class MockCacheCest
 
         $I->assertSame(["key1" => "value1", "key2" => "value2", "key3" => false], $results);
 
-        $I->expectThrowable(InvalidArgumentException::class, function () {
+        $I->expectThrowable(TypeError::class, function () {
             $this->cache->getMultiple("Invalid type");
         });
 
-        $I->expectThrowable(InvalidArgumentException::class, function () {
+        $I->expectThrowable(TypeError::class, function () {
             $this->cache->setMultiple("Invalid type");
         });
 


### PR DESCRIPTION
- Updated simple-cache to ^3
- Adjusted implementation according to interface changes done in simple-cache ^3
- Corrected tests that were failing because they were expecting `InvalidArgumentError` but received a `TypeError` caused by the addition of type hints.